### PR TITLE
Move to fine-grained locking on Element

### DIFF
--- a/lib/src/main/java/eu/aylett/arc/internal/DelayManager.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/DelayManager.java
@@ -16,6 +16,7 @@
 
 package eu.aylett.arc.internal;
 
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import java.time.Duration;
@@ -46,13 +47,14 @@ public final class DelayManager {
     return delayedElement;
   }
 
+  @MayReleaseLocks
   public void poll() {
     DelayedElement element;
-    while ((element = queue.poll()) != null) {
-      element.expireFromDelay();
-    }
     while ((element = refreshQueue.poll()) != null) {
       element.refresh();
+    }
+    while ((element = queue.poll()) != null) {
+      element.expireFromDelay();
     }
   }
 

--- a/lib/src/main/java/eu/aylett/arc/internal/DelayedElement.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/DelayedElement.java
@@ -18,6 +18,7 @@ package eu.aylett.arc.internal;
 
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
 import org.checkerframework.checker.lock.qual.GuardedBy;
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.jspecify.annotations.Nullable;
 
@@ -54,12 +55,24 @@ public final class DelayedElement implements Delayed {
     return result;
   }
 
+  @MayReleaseLocks
   public void expireFromDelay() {
-    element.delayExpired(this);
+    element.lock();
+    try {
+      element.delayExpired(this);
+    } finally {
+      element.unlock();
+    }
   }
 
+  @MayReleaseLocks
   public void refresh() {
-    element.reload();
+    element.lock();
+    try {
+      element.reload();
+    } finally {
+      element.unlock();
+    }
   }
 
   @Override
@@ -74,5 +87,11 @@ public final class DelayedElement implements Delayed {
   @Override
   public int hashCode(@GuardSatisfied DelayedElement this) {
     return Objects.hash(element, expiryTime);
+  }
+
+  @Override
+  @SideEffectFree
+  public String toString(@GuardSatisfied DelayedElement this) {
+    return "DelayedElement{" + "element=" + element + ", expiryTime=" + expiryTime + '}';
   }
 }

--- a/lib/src/main/java/eu/aylett/arc/internal/ExpiredElementList.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/ExpiredElementList.java
@@ -16,9 +16,12 @@
 
 package eu.aylett.arc.internal;
 
+import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
 import org.checkerframework.checker.lock.qual.GuardedBy;
+import org.checkerframework.checker.lock.qual.Holding;
 import org.checkerframework.checker.lock.qual.LockingFree;
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
 import org.checkerframework.checker.lock.qual.ReleasesNoLocks;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
@@ -26,13 +29,14 @@ import org.checkerframework.dataflow.qual.SideEffectFree;
 import java.util.HashMap;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The ElementList class represents a queue used to manage elements in the
  * cache. It supports operations to grow, shrink, and evict elements based on
  * the list's capacity.
  */
-class ExpiredElementList extends ElementList {
+abstract class ExpiredElementList extends ElementList {
 
   /** The maximum number of elements the list may hold. */
   private final int capacity;
@@ -40,30 +44,36 @@ class ExpiredElementList extends ElementList {
   private final Queue<Element<?, ?>> queue;
 
   /** The current number of elements in the list. */
-  private int size;
+  private AtomicInteger size = new AtomicInteger(0);
 
   @LockingFree
-  ExpiredElementList(Name name, int capacity) {
-    super(name);
+  ExpiredElementList(ListId name, int capacity, @UnderInitialization InnerArc inner) {
+    super(name, inner);
     this.capacity = capacity;
     this.queue = new ConcurrentLinkedQueue<>();
   }
 
-  @ReleasesNoLocks
+  @MayReleaseLocks
   @Override
   void checkSafety(@GuardedBy ExpiredElementList this) {
     var seen = new HashMap<Element<?, ?>, Integer>();
+    var initialSize = this.size.get();
     for (var element : queue) {
-      var owner = element.getOwner();
-      if (owner != this) {
-        continue;
-      }
-      seen.compute(element, (k, v) -> v == null ? 1 : v + 1);
-      if (element.containsValue()) {
-        throw new IllegalStateException("Element in expired list has a value: " + element);
+      element.lock();
+      try {
+        var owner = element.getOwner();
+        if (owner != this) {
+          continue;
+        }
+        seen.compute(element, (k, v) -> v == null ? 1 : v + 1);
+        if (element.containsValue()) {
+          throw new IllegalStateException("Element in expired list has a value: " + element);
+        }
+      } finally {
+        element.unlock();
       }
     }
-    if (seen.size() != this.size) {
+    if (seen.size() != initialSize) {
       throw new IllegalStateException("Size mismatch: found " + seen.size() + " items != expected " + this.size);
     }
     seen.forEach((k, v) -> {
@@ -72,7 +82,7 @@ class ExpiredElementList extends ElementList {
       }
     });
 
-    if (size > capacity) {
+    if (initialSize > capacity) {
       throw new IllegalStateException("Size of " + size + " exceeds capacity of " + capacity + ": " + this);
     }
   }
@@ -91,28 +101,37 @@ class ExpiredElementList extends ElementList {
    *          the new element to add
    */
   @ReleasesNoLocks
+  @Holding("#1.lock")
   @Override
-  void push(@GuardedBy ExpiredElementList this, Element<?, ?> newElement) {
+  void push(Element<?, ?> newElement) {
     if (newElement.containsValue()) {
       throw new IllegalStateException("Attempted to add an element with a value to an expired list: " + newElement);
     }
     var newlyAdded = newElement.addRef(this);
     queue.add(newElement);
     if (newlyAdded) {
-      size += 1;
+      size.incrementAndGet();
     }
-    evict();
   }
 
   /** Evicts the least recently used element if the list exceeds its capacity. */
-  @ReleasesNoLocks
+  @MayReleaseLocks
   @Override
-  void evict(@GuardedBy ExpiredElementList this) {
-    while (this.size > this.capacity) {
+  void evict() {
+    while (true) {
+      var decrementedSize = size.decrementAndGet();
+      if (decrementedSize < capacity) {
+        size.incrementAndGet();
+        return;
+      }
+
       var victim = queue.remove();
-      var expired = victim.removeRef(this);
-      if (expired) {
-        this.size -= 1;
+      victim.lock();
+      try {
+        victim.removeRef(this);
+        size.incrementAndGet();
+      } finally {
+        victim.unlock();
       }
     }
   }
@@ -125,7 +144,36 @@ class ExpiredElementList extends ElementList {
 
   @Override
   public void noteRemovedElement() {
-    this.size -= 1;
+    this.size.decrementAndGet();
   }
 
+  @ReleasesNoLocks
+  @Holding("#1.lock")
+  public abstract void processElement(Element<?, ?> e);
+
+  public static class SeenOnce extends ExpiredElementList {
+    public SeenOnce(int capacity, @UnderInitialization InnerArc inner) {
+      super(ListId.SEEN_ONCE_EXPIRING, capacity, inner);
+    }
+
+    @ReleasesNoLocks
+    @Holding("#1.lock")
+    @Override
+    public void processElement(Element<?, ?> e) {
+      inner.enqueueSeenOnceElement(e);
+    }
+  }
+
+  public static class SeenMulti extends ExpiredElementList {
+    public SeenMulti(int capacity, @UnderInitialization InnerArc inner) {
+      super(ListId.SEEN_MULTI_EXPIRING, capacity, inner);
+    }
+
+    @ReleasesNoLocks
+    @Holding("#1.lock")
+    @Override
+    public void processElement(Element<?, ?> e) {
+      inner.enqueueSeenMultiElement(e);
+    }
+  }
 }

--- a/lib/src/main/java/eu/aylett/arc/internal/ListId.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/ListId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Andrew Aylett
+ * Copyright 2024-2025 Andrew Aylett
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 package eu.aylett.arc.internal;
 
-enum ListId {
-  SEEN_ONCE_LRU, SEEN_MULTI_LRU, SEEN_ONCE_EXPIRING, SEEN_MULTI_EXPIRING,
+public enum ListId {
+  SEEN_ONCE_LRU, SEEN_MULTI_LRU, SEEN_ONCE_EXPIRING, SEEN_MULTI_EXPIRING, UNOWNED
 }

--- a/lib/src/main/java/eu/aylett/arc/internal/UnownedElementList.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/UnownedElementList.java
@@ -16,48 +16,50 @@
 
 package eu.aylett.arc.internal;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 import org.checkerframework.checker.lock.qual.Holding;
-import org.checkerframework.checker.lock.qual.LockingFree;
 import org.checkerframework.checker.lock.qual.MayReleaseLocks;
 import org.checkerframework.checker.lock.qual.ReleasesNoLocks;
-import org.checkerframework.dataflow.qual.Pure;
 
-public abstract class ElementList {
-  public final ListId name;
-  protected @NotOnlyInitialized InnerArc inner;
-
-  @LockingFree
-  @SuppressFBWarnings("EI2")
-  public ElementList(ListId name, @UnderInitialization InnerArc inner) {
-    this.name = name;
-    this.inner = inner;
+public class UnownedElementList extends ElementList {
+  public UnownedElementList(@UnderInitialization InnerArc inner) {
+    super(ListId.UNOWNED, inner);
   }
 
-  @MayReleaseLocks
-  abstract void checkSafety();
-
-  @Pure
-  abstract boolean isForExpiredElements();
-
-  @ReleasesNoLocks
-  @Holding("#1.lock")
-  abstract void push(Element<?, ?> newElement);
-
-  @MayReleaseLocks
-  abstract void evict();
-
-  public abstract void noteRemovedElement();
-
-  @ReleasesNoLocks
-  @Holding("#1.lock")
-  public DelayedElement delayManage(Element<?, ?> element) {
-    return inner.delayManage(element);
+  @Override
+  boolean isForExpiredElements() {
+    return true;
   }
 
+  @Override
   @ReleasesNoLocks
   @Holding("#1.lock")
-  public abstract void processElement(Element<?, ?> kvElement);
+  void push(Element<?, ?> newElement) {
+    // We don't remember unowned elements, so we only addRef
+    newElement.addRef(this);
+  }
+
+  @Override
+  void evict() {
+    // No eviction needed for unowned elements.
+  }
+
+  @Override
+  public void noteRemovedElement() {
+    // No action needed for unowned elements.
+  }
+
+  @Override
+  @ReleasesNoLocks
+  @Holding("#1.lock")
+  public void processElement(Element<?, ?> e) {
+    // New or expired out of the cache
+    inner.enqueueNewElement(e);
+  }
+
+  @Override
+  @MayReleaseLocks
+  public void checkSafety() {
+    inner.checkSafety();
+  }
 }


### PR DESCRIPTION
This swaps around ownership somewhat, as we need to lock the element while we use it.  We rely on atomic operations and eventual consistency via eviction to maintain the lists in their correct form, trying to avoid holding locks for multiple elements in the same thread.

Only having a thread own a single element lock, and having the eviction lock be also run on a separate thread to requests, means we should be safe from deadlock.

We never take the eviction lock when holding an element lock, and we never take a second element lock when holding an element lock.  It is safe to take an element lock while holding the eviction lock.