### PR TITLE
Adopt a fluent builder pattern for creating an Arc

### DIFF
--- a/lib/src/main/java/eu/aylett/arc/Arc.java
+++ b/lib/src/main/java/eu/aylett/arc/Arc.java
@@ -21,11 +21,12 @@ import eu.aylett.arc.internal.Element;
 import eu.aylett.arc.internal.InnerArc;
 import eu.aylett.arc.internal.UnownedElementList;
 import org.checkerframework.checker.lock.qual.MayReleaseLocks;
+import org.checkerframework.checker.lock.qual.NewObject;
+import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.ref.SoftReference;
-import java.time.Clock;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.concurrent.CompletableFuture;
@@ -67,52 +68,15 @@ public final class Arc<K extends @NonNull Object, V extends @NonNull Object> {
   private final InnerArc inner;
   private final AtomicBoolean needsEviction = new AtomicBoolean(false);
 
-  /**
-   * Constructs a new Arc with the specified capacity, loader function, and the
-   * common ForkJoinPool.
-   *
-   * @param capacity
-   *          the maximum number of elements the cache can hold
-   * @param loader
-   *          the function to load values
-   * @param expiry
-   *          how long after finishing loading a value it should be discarded
-   * @param refresh
-   *          if a value is used more than once in the refresh interval after
-   *          loading, we will refresh it
-   */
-  public Arc(int capacity, Function<K, V> loader, Duration expiry, Duration refresh) {
-    this(capacity, loader, ForkJoinPool.commonPool(), expiry, refresh, Clock.systemUTC());
+  @Contract("_, _ -> new")
+  public static <K extends @NonNull Object, V extends @NonNull Object> @NewObject Arc<K, V> build(Function<K, V> loader,
+      int capacity) {
+    return new ArcBuilder().build(loader, capacity);
   }
 
-  /**
-   * Constructs a new Arc with the specified capacity, loader function, and
-   * ForkJoinPool.
-   *
-   * @param capacity
-   *          the maximum number of elements the cache can hold
-   * @param loader
-   *          the function to load values
-   * @param pool
-   *          the ForkJoinPool that the loader will be submitted to
-   */
-  public Arc(int capacity, Function<? super K, V> loader, ForkJoinPool pool) {
-    this(capacity, loader, Duration.ofSeconds(60), Duration.ofSeconds(30), pool);
-  }
-
-  /**
-   * Constructs a new Arc with the specified capacity, loader function, and
-   * ForkJoinPool.
-   *
-   * @param capacity
-   *          the maximum number of elements the cache can hold
-   * @param loader
-   *          the function to load values
-   * @param pool
-   *          the ForkJoinPool that the loader will be submitted to
-   */
-  public Arc(int capacity, Function<? super K, V> loader, Duration expiry, Duration refresh, ForkJoinPool pool) {
-    this(capacity, loader, pool, expiry, refresh, Clock.systemUTC());
+  @Contract(" -> new")
+  public static @NewObject ArcBuilder builder() {
+    return new ArcBuilder();
   }
 
   Arc(int capacity, Function<? super K, V> loader, ForkJoinPool pool, Duration expiry, Duration refresh,

--- a/lib/src/main/java/eu/aylett/arc/ArcBuilder.java
+++ b/lib/src/main/java/eu/aylett/arc/ArcBuilder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.arc;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.checkerframework.checker.lock.qual.NewObject;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.NonNull;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class ArcBuilder {
+
+  private Duration expiry = Duration.ofSeconds(60);
+  private Duration refresh = Duration.ofSeconds(30);
+  private ForkJoinPool pool = ForkJoinPool.commonPool();
+  private InstantSource clock = Clock.systemUTC();
+
+  ArcBuilder() {
+  }
+
+  public ArcBuilder withExpiry(Duration expiry) {
+    this.expiry = checkNotNull(expiry);
+    return this;
+  }
+
+  public ArcBuilder withRefresh(Duration refresh) {
+    this.refresh = checkNotNull(refresh);
+    return this;
+  }
+
+  @SuppressFBWarnings("EI2")
+  @Contract("_ -> this")
+  public ArcBuilder withPool(ForkJoinPool pool) {
+    this.pool = checkNotNull(pool);
+    return this;
+  }
+
+  @Contract("_ -> this")
+  public ArcBuilder withClock(InstantSource clock) {
+    this.clock = checkNotNull(clock);
+    return this;
+  }
+
+  @Contract(value = "_, _ -> new", pure = true)
+  public <K extends @NonNull Object, V extends @NonNull Object> @NewObject Arc<K, V> build(Function<K, V> loader,
+      int capacity) {
+    checkNotNull(loader, "Loader function must be provided");
+    checkArgument(capacity > 0, "Capacity must be greater than zero");
+    return new Arc<>(capacity, loader, pool, expiry, refresh, clock);
+  }
+}


### PR DESCRIPTION
Stuff that's either supposed to be optional or has defaults doesn't need to be listed out in _n_ constructors.