### PR TITLE
Don't apply Checker Framework to tests

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -59,6 +59,7 @@ java {
 testing {
   suites {
     // Configure the built-in test suite
+    @Suppress("unused")
     val test by
         getting(JvmTestSuite::class) {
           // Use JUnit Jupiter test framework
@@ -81,6 +82,7 @@ configure<CheckerFrameworkExtension> {
           "org.checkerframework.common.initializedfields.InitializedFieldsChecker",
           "org.checkerframework.checker.lock.LockChecker",
       )
+  excludeTests = true
 }
 
 spotless {


### PR DESCRIPTION
A big chunk of what we want to test is what happens when we break the invariants -- so we were suppressing a lot of warnings.