### PR TITLE
Factor out different DelayManager implementations

### DIFF
--- a/lib/src/main/java/eu/aylett/arc/Arc.java
+++ b/lib/src/main/java/eu/aylett/arc/Arc.java
@@ -27,8 +27,6 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.ref.SoftReference;
-import java.time.Duration;
-import java.time.InstantSource;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
@@ -79,17 +77,13 @@ public final class Arc<K extends @NonNull Object, V extends @NonNull Object> {
     return new ArcBuilder();
   }
 
-  Arc(int capacity, Function<? super K, V> loader, ForkJoinPool pool, Duration expiry, Duration refresh,
-      InstantSource clock) {
+  Arc(int capacity, Function<? super K, V> loader, ForkJoinPool pool, DelayManager delayManager) {
     checkArgument(capacity > 0, "Capacity must be at least 1");
-    checkArgument(expiry.compareTo(refresh) >= 0, "Expiry must be greater than refresh");
-    checkArgument(expiry.isPositive(), "Expiry must be positive");
-    checkArgument(refresh.isPositive(), "Refresh must be positive");
 
     this.loader = checkNotNull(loader);
     this.pool = checkNotNull(pool);
     elements = new ConcurrentHashMap<>();
-    inner = new InnerArc(Math.max(capacity / 2, 1), new DelayManager(expiry, refresh, clock));
+    inner = new InnerArc(Math.max(capacity / 2, 1), delayManager);
     unowned = inner.unowned;
   }
 

--- a/lib/src/main/java/eu/aylett/arc/internal/ExpireAndRefreshDelayManager.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/ExpireAndRefreshDelayManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.arc.internal;
+
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
+
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.concurrent.DelayQueue;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class ExpireAndRefreshDelayManager extends DelayManager {
+  private final DelayQueue<TimeDelayedElement> queue;
+  private final DelayQueue<TimeDelayedElement> refreshQueue;
+  private final Duration expiry;
+  private final Duration refresh;
+
+  public ExpireAndRefreshDelayManager(Duration expiry, Duration refresh, InstantSource timeSource) {
+    super(timeSource);
+    checkArgument(expiry.compareTo(refresh) >= 0, "Expiry must be greater than refresh");
+    checkArgument(expiry.isPositive(), "Expiry must be positive");
+    checkArgument(refresh.isPositive(), "Refresh must be positive");
+    this.queue = new DelayQueue<>();
+    this.refreshQueue = new DelayQueue<>();
+    this.expiry = expiry;
+    this.refresh = refresh;
+  }
+
+  @Override
+  public DelayedElement add(Element<?, ?> element) {
+    var epochMilli = timeSource.instant().toEpochMilli();
+    var delayedElement = new TimeDelayedElement(element, this::getDelay, epochMilli + expiry.toMillis());
+    queue.add(delayedElement);
+    refreshQueue.add(new TimeDelayedElement(element, this::getDelay, epochMilli + refresh.toMillis()));
+    return delayedElement;
+  }
+
+  @MayReleaseLocks
+  @Override
+  public void poll() {
+    TimeDelayedElement element;
+    while ((element = refreshQueue.poll()) != null) {
+      element.refresh();
+    }
+    while ((element = queue.poll()) != null) {
+      element.expireFromDelay();
+    }
+  }
+
+}

--- a/lib/src/main/java/eu/aylett/arc/internal/ExpiringDelayManager.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/ExpiringDelayManager.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.arc.internal;
+
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
+
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.concurrent.DelayQueue;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class ExpiringDelayManager extends DelayManager {
+  private final DelayQueue<TimeDelayedElement> queue;
+  private final Duration expiry;
+
+  public ExpiringDelayManager(Duration expiry, InstantSource timeSource) {
+    super(timeSource);
+    checkArgument(expiry.isPositive(), "Expiry must be positive");
+    this.queue = new DelayQueue<>();
+    this.expiry = expiry;
+  }
+
+  @Override
+  public DelayedElement add(Element<?, ?> element) {
+    var epochMilli = timeSource.instant().toEpochMilli();
+    var delayedElement = new TimeDelayedElement(element, this::getDelay, epochMilli + expiry.toMillis());
+    queue.add(delayedElement);
+    return delayedElement;
+  }
+
+  @MayReleaseLocks
+  @Override
+  public void poll() {
+    TimeDelayedElement element;
+    while ((element = queue.poll()) != null) {
+      element.expireFromDelay();
+    }
+  }
+}

--- a/lib/src/main/java/eu/aylett/arc/internal/NoOpDelayManager.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/NoOpDelayManager.java
@@ -16,5 +16,23 @@
 
 package eu.aylett.arc.internal;
 
-public abstract class DelayedElement {
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
+
+import java.time.InstantSource;
+
+public final class NoOpDelayManager extends DelayManager {
+
+  public NoOpDelayManager(InstantSource timeSource) {
+    super(timeSource);
+  }
+
+  @Override
+  public DelayedElement add(Element<?, ?> element) {
+    return new NoOpDelayedElement();
+  }
+
+  @MayReleaseLocks
+  @Override
+  public void poll() {
+  }
 }

--- a/lib/src/main/java/eu/aylett/arc/internal/NoOpDelayedElement.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/NoOpDelayedElement.java
@@ -16,5 +16,5 @@
 
 package eu.aylett.arc.internal;
 
-public abstract class DelayedElement {
+public class NoOpDelayedElement extends DelayedElement {
 }

--- a/lib/src/main/java/eu/aylett/arc/internal/TimeDelayedElement.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/TimeDelayedElement.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.arc.internal;
+
+import org.checkerframework.checker.lock.qual.GuardSatisfied;
+import org.checkerframework.checker.lock.qual.MayReleaseLocks;
+import org.checkerframework.dataflow.qual.SideEffectFree;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Objects;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+public final class TimeDelayedElement extends DelayedElement implements Delayed {
+  public final Element<?, ?> element;
+
+  private final long expiryTime;
+  private final DelayManager.GetDelay manager;
+
+  public TimeDelayedElement(Element<?, ?> element, DelayManager.GetDelay manager, long expiryTime) {
+    this.element = element;
+    this.expiryTime = expiryTime;
+    this.manager = manager;
+  }
+
+  @Override
+  @SideEffectFree
+  public long getDelay(TimeUnit unit) {
+    return manager.getDelay(expiryTime, unit);
+  }
+
+  @Override
+  @SuppressWarnings("override.receiver")
+  public int compareTo(Delayed o) {
+    if (o instanceof TimeDelayedElement other) {
+      return Long.compare(expiryTime, other.expiryTime);
+    }
+    @SuppressWarnings("method.guarantee.violated")
+    var result = Long.compare(getDelay(TimeUnit.MILLISECONDS), o.getDelay(TimeUnit.MILLISECONDS));
+    return result;
+  }
+
+  @MayReleaseLocks
+  public void expireFromDelay() {
+    element.lock();
+    try {
+      element.delayExpired(this);
+    } finally {
+      element.unlock();
+    }
+  }
+
+  @MayReleaseLocks
+  public void refresh() {
+    element.lock();
+    try {
+      element.reload();
+    } finally {
+      element.unlock();
+    }
+  }
+
+  @Override
+  @SuppressWarnings("instanceof.pattern.unsafe")
+  public boolean equals(@GuardSatisfied TimeDelayedElement this, @GuardSatisfied @Nullable Object o) {
+    if (o instanceof TimeDelayedElement that) {
+      return expiryTime == that.expiryTime && Objects.equals(element, that.element);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode(@GuardSatisfied TimeDelayedElement this) {
+    return Objects.hash(element, expiryTime);
+  }
+
+  @Override
+  @SideEffectFree
+  public String toString(@GuardSatisfied TimeDelayedElement this) {
+    return "DelayedElement{" + "element=" + element + ", expiryTime=" + expiryTime + '}';
+  }
+}


### PR DESCRIPTION
This allows configurable expiry or refresh if either isn't necessary, without changing the rest of the system.