### PR TITLE
Add validation of lock ordering

### DIFF
--- a/lib/src/main/java/eu/aylett/arc/internal/ExpiredElementList.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/ExpiredElementList.java
@@ -60,7 +60,7 @@ abstract class ExpiredElementList extends ElementList {
     var seen = new HashMap<Element<?, ?>, Integer>();
     var initialSize = this.size.get();
     for (var element : queue) {
-      element.lock();
+      var release = element.lock();
       try {
         var owner = element.getOwner();
         if (owner != this) {
@@ -69,7 +69,7 @@ abstract class ExpiredElementList extends ElementList {
         seen.compute(element, (k, v) -> v == null ? 1 : v + 1);
         verify(!element.containsValue(), "Element in expired list has a value: %s", element);
       } finally {
-        element.unlock();
+        element.unlock(release);
       }
     }
     verify(seen.size() == initialSize, "Size mismatch: found %s items != expected %s", seen.size(), this.size);
@@ -112,12 +112,12 @@ abstract class ExpiredElementList extends ElementList {
       }
 
       var victim = queue.remove();
-      victim.lock();
+      var release = victim.lock();
       try {
         victim.removeRef(this);
         size.incrementAndGet();
       } finally {
-        victim.unlock();
+        victim.unlock(release);
       }
     }
   }

--- a/lib/src/main/java/eu/aylett/arc/internal/LRUElementList.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/LRUElementList.java
@@ -73,7 +73,7 @@ public class LRUElementList extends ElementList {
     var seen = new HashMap<Element<?, ?>, Integer>();
     var startSize = this.size.get();
     for (var element : queue) {
-      element.lock();
+      var release = element.lock();
       try {
         var owner = element.getOwner();
         if (owner != this) {
@@ -83,7 +83,7 @@ public class LRUElementList extends ElementList {
         verify(element.containsValue() || !element.containsWeakValue(), "Element in LRU list has only weak value: %s",
             element);
       } finally {
-        element.unlock();
+        element.unlock(release);
       }
     }
     verify(seen.size() == startSize, "Size mismatch: found %s items != expected %s", seen.size(), startSize);
@@ -152,7 +152,7 @@ public class LRUElementList extends ElementList {
         return;
       }
       var victim = queue.remove();
-      victim.lock();
+      var release = victim.lock();
       try {
         var expired = victim.removeRef(this);
         if (expired) {
@@ -160,7 +160,7 @@ public class LRUElementList extends ElementList {
         }
         this.size.incrementAndGet();
       } finally {
-        victim.unlock();
+        victim.unlock(release);
       }
     } while (true);
   }

--- a/lib/src/main/java/eu/aylett/arc/internal/LockOrderGuard.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/LockOrderGuard.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.arc.internal;
+
+import org.jspecify.annotations.Nullable;
+
+import static com.google.common.base.Verify.verify;
+
+public class LockOrderGuard {
+  private final ThreadLocal<@Nullable Element<?, ?>> elementLockHeld = ThreadLocal.withInitial(() -> null);
+
+  public Release markThreadHoldingLock(Element<?, ?> element) {
+    var oldElement = elementLockHeld.get();
+    verify(oldElement == null, "Thread already holding a lock: %s", oldElement);
+
+    elementLockHeld.set(element);
+
+    return () -> {
+      var heldElement = elementLockHeld.get();
+      verify(heldElement == element, "Thread holding a different lock.  Expected %s, found %s", element, heldElement);
+      elementLockHeld.remove();
+    };
+  }
+
+  public void assertNoElementLockHeld() {
+    var heldElement = elementLockHeld.get();
+    verify(heldElement == null, "Thread already holding a lock on: %s", heldElement);
+  }
+
+  public interface Release {
+    void release();
+  }
+}

--- a/lib/src/main/java/eu/aylett/arc/internal/TimeDelayedElement.java
+++ b/lib/src/main/java/eu/aylett/arc/internal/TimeDelayedElement.java
@@ -56,21 +56,21 @@ public final class TimeDelayedElement extends DelayedElement implements Delayed 
 
   @MayReleaseLocks
   public void expireFromDelay() {
-    element.lock();
+    var release = element.lock();
     try {
       element.delayExpired(this);
     } finally {
-      element.unlock();
+      element.unlock(release);
     }
   }
 
   @MayReleaseLocks
   public void refresh() {
-    element.lock();
+    var release = element.lock();
     try {
       element.reload();
     } finally {
-      element.unlock();
+      element.unlock(release);
     }
   }
 


### PR DESCRIPTION
This ensures we only take a single element lock at once, and also that we don't try to take the expiry lock while holding an element lock.

Taking an element lock while holding the expiry lock is expected.